### PR TITLE
fix: 修复 blurhash 缓存文件名未做区分导致不同参数配置渲染结果相同的问题

### DIFF
--- a/harmony/blurhash/src/main/cpp/Blurhash.cpp
+++ b/harmony/blurhash/src/main/cpp/Blurhash.cpp
@@ -219,7 +219,9 @@ std::string decode(std::string_view blurhash, size_t width, size_t height, float
     i.height = height;
     i.width = width;
 
-    std::string filename = path + std::string(blurhash) + ".bmp";
+    std::string filename = path + std::string(blurhash) + "_" + 
+                        std::to_string(width) + "x" + std::to_string(height) + 
+                        "_p" + std::to_string(static_cast<int>(punch * 100)) + ".bmp";
     stbi_write_bmp(filename.c_str(), i.width, i.height, 3, (void *)i.image.data());
     return filename;
 }

--- a/harmony/blurhash/src/main/cpp/BlurhashViewComponentInstance.cpp
+++ b/harmony/blurhash/src/main/cpp/BlurhashViewComponentInstance.cpp
@@ -78,7 +78,9 @@ void BlurhashViewComponentInstance::onPropsChanged(SharedConcreteProps const &pr
 }
 
 std::string BlurhashViewComponentInstance::decodeImageByBlurhash(const std::string &blurhash, const int &width, const int &height, const float &punch) {
-    std::string expectedName = blurhash + ".bmp";
+    std::string expectedName =
+        blurhash + "_" + std::to_string(width) + "x" + std::to_string(height) +
+        "_p" + std::to_string(static_cast<int>(punch * 100)) + ".bmp";
     blurhash::decode(blurhash, width, height, punch);
     auto rnInstance = m_deps->rnInstance.lock();
     auto turboModule = rnInstance->getTurboModule("ImageLoader");


### PR DESCRIPTION
# Summary

fix: 修复 blurhash 缓存文件名未做区分导致不同参数配置渲染结果相同的问题

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)